### PR TITLE
Bug Fix bsekerneldb

### DIFF
--- a/yambopy/dbs/bsekerneldb.py
+++ b/yambopy/dbs/bsekerneldb.py
@@ -73,6 +73,8 @@ class YamboBSEKernelDB(YamboSaveDB):
 
         # Basis transformation
         kernel_exc_basis = np.zeros(Nstates,dtype=np.complex_)
+        # improve efficiency RR:
+        #kernel_exc_basis  = np.einsum('ij,kj,ki->k', kernel, eivs, np.conj(eivs), optimize=True)
         for il in range(Nstates):
             kernel_exc_basis[il] = np.dot( np.conj(eivs[il]), np.dot(kernel,eivs[il]) )
 
@@ -104,8 +106,8 @@ class YamboBSEKernelDB(YamboSaveDB):
 
         # Iterate only on the subset
         for it1_subset, it2_subset in product(t_vc,repeat=2):
-            ik = table[it1_subset][0]
-            ip = table[it2_subset][0]
+            ik = table[t_v[it1_subset]][0]
+            ip = table[t_v[it2_subset]][0]
             Wcv[ik-1,ip-1] = kernel[it1_subset,it2_subset]
 
         return Wcv


### PR DESCRIPTION
I found a potential bug in `bsekerneldb.py` in the call to `get_kernel_value_bands` and propose the solution below.

Moreover, I propose to increase the efficiency of this file in the call to `get_kernel_exciton_basis`. See commented line which should substitute the for loop.
In general, I think we should use `np.einsum` almost everywhere instead of for loops.

The change in `get_kernel_value_bands` has been tested for my TMDs heterostructures. Is there a small test system that can be used for this functionality? Perhaps, hBN-2D?

