### PR TITLE
Bug fix PW.py

### DIFF
--- a/qepy/pw.py
+++ b/qepy/pw.py
@@ -680,8 +680,8 @@ class PwIn(object):
                     self.klist = [ [a,b,c,int(d)] for a,b,c,d in self.klist ]
 
     def slicefile(self, keyword):
-        file_slice_regexp = '&%s(?:.?)+\n((?:.+\n)+?)(?:\s+)?[\/&]'%keyword
-        lines = re.findall(file_slice_regexp,"".join(self.file_lines),re.MULTILINE)
+        file_slice_regexp = f'&{keyword}(?:.?)+\n((?:.+\n)+?)(?:\s+)?[\/&]'
+        lines = re.findall(file_slice_regexp,"".join(self.file_lines),re.MULTILINE | re.IGNORECASE)
         return lines
 
     def store(self,group,name):

--- a/qepy/pw.py
+++ b/qepy/pw.py
@@ -688,7 +688,7 @@ class PwIn(object):
         """
         Save the variables specified in each of the groups on the structure
         """
-        group_regexp = '([a-zA-Z_0-9\(\)]+)\s*=\s*([\d.-]+d[+\-]\d+|[a-zA-Z/\'"0-9_.-]+)'   ## also match scientific notation
+        group_regexp = '([a-zA-Z_0-9_\(\)]+)(?:\s+)?=(?:\s+)?([a-zA-Z\'"0-9_.+-]+)' 
         for file_slice in self.slicefile(name):
             for keyword, value in re.findall(group_regexp,file_slice):
                 group[keyword.strip()]=value.strip()

--- a/qepy/pw.py
+++ b/qepy/pw.py
@@ -688,7 +688,7 @@ class PwIn(object):
         """
         Save the variables specified in each of the groups on the structure
         """
-        group_regexp = '([a-zA-Z_0-9_\(\)]+)(?:\s+)?=(?:\s+)?([a-zA-Z/\'"0-9_.-]+)'
+        group_regexp = '([a-zA-Z_0-9\(\)]+)\s*=\s*([\d.-]+d[+\-]\d+|[a-zA-Z/\'"0-9_.-]+)'   ## also match scientific notation
         for file_slice in self.slicefile(name):
             for keyword, value in re.findall(group_regexp,file_slice):
                 group[keyword.strip()]=value.strip()
@@ -698,7 +698,7 @@ class PwIn(object):
             string='&%s\n' % keyword
             for keyword in sorted(group): # Py2/3 discrepancy in keyword order
                 string += "%20s = %s\n" % (keyword, group[keyword])
-            string += "/&end"
+            string += "/"    ### /%&end does not work for all qe versions
             return string
         else:
             return ''

--- a/qepy/pwxml.py
+++ b/qepy/pwxml.py
@@ -277,7 +277,7 @@ class PwXML():
         return self.atypes
 
     def get_lattice_dict(self):
-        return dict(ibrav=0,cell_parameters=self.cell)
+        return dict(ibrav=self.ibrav,cell_parameters=self.cell)
 
     def get_structure_dict(self):
         """


### PR DESCRIPTION
I allowed the case insenstive reading of a QE input file.
Before the change, it would have not been possible ot create an instance of `PwIn.from_file` if the `INPUT_CARDS` such as `CONTROL/SYSTEM..` would have been capitalized.

Now, the code works both for capital and lowercase naming.

The small change has been tested and works.