### PR TITLE
Fix bug electronsdb

### DIFF
--- a/yambopy/dbs/electronsdb.py
+++ b/yambopy/dbs/electronsdb.py
@@ -110,23 +110,21 @@ class YamboElectronsDB():
         self.nkpoints    = int(dimensions[6])
         self.nbands      = int(dimensions[5])
         self.spin = int(dimensions[12])
-        self.time_rev = dimensions[9]
+        self.spinor_components = int(dimensions[11]) 
+        self.time_rev = dimensions[9] 
         database.close()
-
-        #spin degeneracy if 2 components degen 1 else degen 2
-        self.spin_degen = [0,2,1][int(self.spin)]
-        #number of occupied bands
-        # NB: in the spin-polarised case, nbands contains the total number
-        #     of bands PER spin polarisation, i.e. half of the total number.
-        #     Therefore, nbandsv and nbandsc are also given per
-        #     per spin polarisation: this fact is used by DipolesDB
-        self.nbandsv = int(self.nelectrons/2)
-        self.nbandsc = int(self.nbands-self.nbandsv)
-        if self.spin==2:
-            self.nbands_tot  = self.nbands*self.spin
-            self.nbandsv_tot = int(self.nelectrons/self.spin_degen)
-            self.nbandsc_tot = int(self.nbands_tot-self.nbandsv_tot)
-
+        #spin degeneracy if 2 components degen 1 else degen 2 
+        self.spin_degen = [0,2,1][int(self.spin)] 
+        #number of occupied bands # NB: in the spin-polarised case, nbands contains the total number 
+        # of bands PER spin polarisation, i.e. half of the total number. 
+        # Therefore, nbandsv and nbandsc are also given per 
+        # per spin polarisation: this fact is used by DipolesDB 
+        if (self.spinor_components==2): 
+            self.nbandsv = int(self.nelectrons) 
+        else: 
+            self.nbandsv = int(self.nelectrons/2) 
+        self.nbandsc = int(self.nbands-self.nbandsv)        
+        
     def expandEigenvalues(self):
         """
         Expand eigenvalues to the full brillouin zone


### PR DESCRIPTION
In the past weeks/month the file 'electronsdb.py' has been changed to properly account for spin polarizations.
However, I saw some inconsistencies in my results with SOC.
Looking into it, I discovered that when we have SOC, `spin=1` but the number of spinor components `spinor_components` is 2.

This affect the `nbandsv` related to the number of electrons and I propose this solution.
I think this needs further discussion, since I am not sure how this should be handled.
