### PR TITLE
speedup get_qps

### DIFF
--- a/yambopy/dbs/qpdb.py
+++ b/yambopy/dbs/qpdb.py
@@ -39,7 +39,7 @@ class YamboQPDB():
         self.qpz          = np.array(qps['Z']).real
         self.spin         = False
         if 'Spin_pol' in qps.keys():
-            self.spin_pol = qps['Spin_pol']
+            self.spin_pol = np.array(qps['Spin_pol'],dtype=int)
             self.spin     = True
 
     @property
@@ -84,58 +84,52 @@ class YamboQPDB():
         """
         Get quasiparticle energies in a list
         """
-        #start arrays
+        # Get values once to avoid multiple property calls
+        min_k = self.min_kpoint
+        min_b = self.min_band
+        max_k = self.max_kpoint
+        nb_tot = self.nbands
+        nk_tot = self.nkpoints
+        
+        ncalculatedkpoints = max_k - min_k + 1
+        
+        # position in array
+        nk_idx = self.kpoint_index - min_k
+        nb_idx = self.band_index - min_b
 
-        # If spin polarisation is present, arrays have one additional dimension
+        if self.spin:
+            sp_idx = self.spin_pol - 1
+            
+            eigenvalues_dft = np.zeros([ncalculatedkpoints, nb_tot, 2])
+            eigenvalues_qp  = np.zeros([ncalculatedkpoints, nb_tot, 2])
+            linewidths      = np.zeros([ncalculatedkpoints, nb_tot, 2])
+            z               = np.zeros([nk_tot, nb_tot, 2])
 
-        # shift
-        ncalculatedkpoints = self.max_kpoint - self.min_kpoint + 1
-        if self.spin is True:
-           eigenvalues_dft = np.zeros([ncalculatedkpoints,self.nbands,2])
-           eigenvalues_qp  = np.zeros([ncalculatedkpoints,self.nbands,2])
-           linewidths      = np.zeros([ncalculatedkpoints,self.nbands,2])
-           z               = np.zeros([self.nkpoints,self.nbands,2])
-
-           for ei,e0i,li,zi,ki,ni,s_pol in zip(self.e,self.e0,self.linewidths,self.qpz,self.kpoint_index,self.band_index,self.spin_pol):
-                # position in array
-                nkpoint = ki - self.min_kpoint 
-                nband   = ni - self.min_band
-                spol    = int(s_pol - 1)
-
-                eigenvalues_dft[nkpoint,nband,spol] = e0i
-                eigenvalues_qp[nkpoint,nband,spol]  = ei
-                linewidths[nkpoint,nband,spol]      = li
-                z[nkpoint,nband,spol]               = zi
-
+            eigenvalues_dft[nk_idx, nb_idx, sp_idx] = self.e0
+            eigenvalues_qp[nk_idx, nb_idx, sp_idx]  = self.e
+            linewidths[nk_idx, nb_idx, sp_idx]      = self.linewidths
+            z[nk_idx, nb_idx, sp_idx]               = self.qpz
         else:
-            eigenvalues_dft = np.zeros([ncalculatedkpoints,self.nbands])
-            eigenvalues_qp  = np.zeros([ncalculatedkpoints,self.nbands])
-            linewidths      = np.zeros([ncalculatedkpoints,self.nbands])
-            z               = np.zeros([self.nkpoints,self.nbands])
+            eigenvalues_dft = np.zeros([ncalculatedkpoints, nb_tot])
+            eigenvalues_qp  = np.zeros([ncalculatedkpoints, nb_tot])
+            linewidths      = np.zeros([ncalculatedkpoints, nb_tot])
+            z               = np.zeros([nk_tot, nb_tot])
 
-            for ei,e0i,li,zi,ki,ni in zip(self.e,self.e0,self.linewidths,self.qpz,self.kpoint_index,self.band_index):
+            eigenvalues_dft[nk_idx, nb_idx] = self.e0
+            eigenvalues_qp[nk_idx, nb_idx]  = self.e
+            linewidths[nk_idx, nb_idx]      = self.linewidths
+            z[nk_idx, nb_idx]               = self.qpz
 
-                # position in array
-                nkpoint = ki - self.min_kpoint 
-                nband   = ni - self.min_band
-
-                eigenvalues_dft[nkpoint,nband] = e0i
-                eigenvalues_qp[nkpoint,nband]  = ei
-                linewidths[nkpoint,nband]      = li
-                z[nkpoint,nband]               = zi
         return eigenvalues_dft, eigenvalues_qp, linewidths, z
 
 
     def get_filtered_qps(self,min_band=None,max_band=None):
         """Return selected QP energies as a flat list"""
-        e0=[]; qp=[]; lw=[]
-        for ei,e0i,li,ki,ni in zip(self.e,self.e0,self.linewidths,self.kpoint_index,self.band_index):
-            if min_band and ni < min_band: continue
-            if max_band and ni > max_band: continue
-            e0.append(e0i)
-            qp.append(ei)
-            lw.append(lw)
-        return e0,qp,lw
+        mask = np.ones(len(self.band_index), dtype=bool)
+        if min_band: mask &= (self.band_index >= min_band)
+        if max_band: mask &= (self.band_index <= max_band)
+        
+        return self.e0[mask].tolist(), self.e[mask].tolist(), self.linewidths[mask].tolist()
 
     def get_direct_gaps(self,valence):
         """
@@ -483,11 +477,11 @@ class YamboQPDB():
 
     @property
     def min_kpoint(self):
-        return min(self.kpoint_index)
+        return self.kpoint_index.min()
 
     @property
     def max_kpoint(self):
-        return max(self.kpoint_index)
+        return self.kpoint_index.max()
 
     @property
     def nbands(self):
@@ -495,11 +489,11 @@ class YamboQPDB():
 
     @property
     def min_band(self):
-        return min(self.band_index)
+        return self.band_index.min()
 
     @property
     def max_band(self):
-        return max(self.band_index)
+        return self.band_index.max()
 
     @property
     def nkpoints(self):


### PR DESCRIPTION
I propose to remove the slow for loops in get_qps. 
I was trying to run on a converged grid and reading db is extremely slow.

With this commit I move some operationrs outside the loop and use broadcasting when possible. The speedup is extreme. The only cons would be that for extremely large database broadcasting is memory costly.

Let me know what you think.