### PR TITLE
fix bug in order of exciton energies in exph_input

### DIFF
--- a/tutorial/exciton-phonon/luminescence.py
+++ b/tutorial/exciton-phonon/luminescence.py
@@ -18,7 +18,6 @@ dipolespath = bsepath # ndb.dipoles is needed (optional)
 # Path to lattice and k-space info
 savepath = f'{path}/SAVE' # ns.db1 database is needed
 
-bands_range=[6,10] # 2 valence, 2 conduction bands
 phonons_range=[0,12] # All phonons
 nexc_out = 12 # 12 excitonic states at each momentum (Lout)
 nexc_in  = 12 # 12 excitonic states at Q=0 (Lin)
@@ -39,7 +38,7 @@ broad = 0.005 # Broadening parameter for peak width (in eV)
 input_data = exc_ph_get_inputs(savepath,elphpath,bsepath,\
                                bse_path2=bseBARpath,dipoles_path=dipolespath,\
                                nexc_in=nexc_in,nexc_out=nexc_out,\
-                               bands_range=bands_range,phonons_range=phonons_range)
+                               phonons_range=phonons_range)
 
 ph_energies, exc_energies, exc_energies_in, G, exc_dipoles = input_data
 
@@ -48,6 +47,10 @@ w,PL = exc_ph_luminescence(T_ph,ph_energies,exc_energies,exc_dipoles,G,\
                            exc_energies_in=exc_energies_in,exc_temp=T_exc,\
                            nexc_out=nexc_out,nexc_in=nexc_in,emin=emin,emax=emax,\
                            estep=estep,broad=broad) #,ph_channels='e')
+
+# Save luminescence intensities
+print("Printing phonon assisted luminescence in 'luminescence.dat' file")
+np.savetxt('luminescence.dat',np.c_[w,PL])
 
 fig = plt.figure()
 ax = fig.add_subplot(1,1,1)

--- a/yambopy/bse/excitondipoles.py
+++ b/yambopy/bse/excitondipoles.py
@@ -131,7 +131,7 @@ def exc_dipoles_pol(lattice_path,dipoles_path=None,bse_path=None,save_files=True
     dip_expanded[time_rev_s] = dip_expanded[time_rev_s].conj()
 
     # Rotate dipoles in exc. basis [n,nblks,nspin,k,c,v] -> [n,k,c,v]
-    BS_wfc = np.squeeze( yexc.get_Akcv() ) # Works in TDA and no spin pol
+    BS_wfc = np.squeeze( yexc.get_Akcv() ,axis=(1,2)) # Works in TDA and no spin pol
     # Since we have dipoles for emission, we do not conjugate BS_wfc
     # Then the results are directly the exciton dipoles for emission
     dip_exc = np.einsum('nkcv,kicv->in',BS_wfc,dip_expanded,

--- a/yambopy/exciton_phonon/excph_input_data.py
+++ b/yambopy/exciton_phonon/excph_input_data.py
@@ -9,7 +9,10 @@ from yambopy.exciton_phonon.excph_matrix_elements import exciton_phonon_matelem
 from yambopy.bse.excitondipoles import exc_dipoles_pol
 from yambopy.kpoints import find_kpt
 
-def exc_ph_get_inputs(lat_path,elph_path,bse_path1,mode='PL',bse_path2=None,wf_path=None,dipoles_path=None,nexc_in='all',nexc_out='all',bands_range=[],phonons_range=[],overwrite=False,dmat_file='Dmats.npy',exph_file='Ex-ph.npy',dip_file='exc_dipoles.npy'):
+def exc_ph_get_inputs(lat_path,elph_path,bse_path1,mode='PL',bse_path2=None,
+                      wf_path=None,dipoles_path=None,nexc_in='all',nexc_out='all',
+                      phonons_range=[],overwrite=False,dmat_file='Dmats.npy',
+                      exph_file='Ex-ph.npy',dip_file='exc_dipoles.npy'):
     """
     This functions creates the necessary inputs for exciton-phonon calculations,
     in the format accepted by the related functions.
@@ -69,12 +72,17 @@ def exc_ph_get_inputs(lat_path,elph_path,bse_path1,mode='PL',bse_path2=None,wf_p
 
     # Load exciton energies (Lout)
     exc_energies = []
+    bands_range = []
     for iq in range(lattice.ibz_nkpoints):
         filename = 'ndb.BS_diago_Q%d' % (iq+1)
         excdb = YamboExcitonDB.from_db_file(lattice,filename=filename,\
                                             folder=bse_path1,Load_WF=False,\
                                             neigs=nexc_out)
         exc_energies.append( excdb.eigenvalues.real )
+        # Get the band indices
+        if (len(bands_range) == 0):
+            bands_range = [np.min(excdb.unique_vbands),np.max(excdb.unique_cbands)+1]
+        #
     exc_energies = np.array(exc_energies)
     exc_energies = exc_energies[lattice.BZ_to_IBZ_indexes,:]
 

--- a/yambopy/exciton_phonon/excph_input_data.py
+++ b/yambopy/exciton_phonon/excph_input_data.py
@@ -7,6 +7,7 @@ import netCDF4
 from yambopy import YamboLatticeDB,YamboExcitonDB,LetzElphElectronPhononDB,YamboDipolesDB,YamboWFDB
 from yambopy.exciton_phonon.excph_matrix_elements import exciton_phonon_matelem
 from yambopy.bse.excitondipoles import exc_dipoles_pol
+from yambopy.kpoints import find_kpt
 
 def exc_ph_get_inputs(lat_path,elph_path,bse_path1,mode='PL',bse_path2=None,wf_path=None,dipoles_path=None,nexc_in='all',nexc_out='all',bands_range=[],phonons_range=[],overwrite=False,dmat_file='Dmats.npy',exph_file='Ex-ph.npy',dip_file='exc_dipoles.npy'):
     """
@@ -99,6 +100,11 @@ def exc_ph_get_inputs(lat_path,elph_path,bse_path1,mode='PL',bse_path2=None,wf_p
                                              dmat_mode=dmat_mode,exph_file=exph_file)
     excph_couplings = excph_couplings[:,phonons_range[0]:phonons_range[1],:nexc_in,:nexc_out]
     
+    # NM : EXciton energies here are (nQ, nexc), but we need (nq,nexc), so get enegies in (nq,nexc)
+    qpoints_ph = elph.qpoints
+    idx_qpts = find_kpt(wfcs.ktree,qpoints_ph)
+    exc_energies = exc_energies[idx_qpts].copy()
+
     if mode=='PL':
         # Calculate excitonic dipoles (not projected along field)
         exc_dipoles = exc_dipoles_pol(lat_path,dipoles_path=dipoles_path,bse_path=bse_path2,overwrite=overwrite,dip_file=dip_file)

--- a/yambopy/kpoints.py
+++ b/yambopy/kpoints.py
@@ -225,39 +225,50 @@ def regular_grid(nk1,nk2,nk3):
     ])
     return xkg.T # shape [nk,3]
 
-def find_kpatch(kpts, kcentre, kdist, lat_vecs):
+
+def find_kpatch(kpts, kcentre, lat_vecs, nshells=1, tol=1e-5, G_range=1):
     """
-    find set of kpoints around the kcentre with in kdist
+    Find k-points belonging to the first `nshells` neighbor shells
+    around kcentre, including degeneracies and rigorous BZ mapping.
 
     Parameters
     ----------
-    kpts : kpoints in crystal coordinates (nk,3)
-    kcentre : kpoint centre in crystal coordinates (3)
-    kdist : distance around kcentre to be considered in atomic units 
-            i.e 1/bohr.
-    lat_vecs: lattice vectors. ith lattice vector is ai = a[:,i]
+    kpts : (nk, 3)
+        k-points in crystal (fractional) coordinates
+    kcentre : (3,)
+        center k-point in crystal coordinates
+    lat_vecs : (3,3)
+        lattice vectors. ith lattice vector is ai = a[:,i]
+    nshells : int
+        number of neighbor shells to include
+    tol : float
+        tolerance for degeneracy
+    G_range : int
+        Range of surrounding reciprocal cells to check. G_range=1 checks 27 cells,
+        which is sufficient when combined with initial rounding.
+
     Returns
     -------
-    int array
-        Indices of kpoints in kpts array which satify the given condition i.e
-        | k - kcentre + G0| <= kdist, where G0 is reciprocal lattice vector to bring to BZ
+    idx : array of int
+        indices of selected k-points
     """
-    #
-    blat = 2*np.pi*np.linalg.inv(lat_vecs)
-    kdiff = kpts-kcentre[None,:]
-    kdiff = kdiff-np.floor(kdiff)
-    #
-    tmp_arr = np.array([-3, -2, -1, 0, 1, 2, 3])
-    nG0 = len(tmp_arr)
-    G0 = np.zeros((nG0,nG0,nG0,3))
-    G0[...,0], G0[...,1], G0[...,2] = np.meshgrid(tmp_arr, tmp_arr,
-                                                  tmp_arr, indexing='ij')
-    G0 = G0.reshape(-1,3)
-    kdiff = kdiff[:,None,:]-G0[None,:,:]
-    kdiff = kdiff.reshape(-1,3)@blat
-    kdiff = np.linalg.norm(kdiff,axis=-1).reshape(len(kpts),-1)
-    kdiff = np.min(kdiff,axis=-1)
-    return np.where(kdiff <= kdist)[0]
+    kcentre = np.array(kcentre)
+    blat = 2 * np.pi * np.linalg.inv(lat_vecs)
+    kdiff = kpts - kcentre[None, :]
+    kdiff = kdiff - np.round(kdiff)
+    g_vals = np.arange(-G_range, G_range + 1)
+    G_grid = np.array(list(product(g_vals, repeat=3)))
+    kdiff_all = kdiff[:, None, :] + G_grid[None, :, :]
+    kcart_all = kdiff_all @ blat
+    dist_all = np.linalg.norm(kcart_all, axis=-1)
+    dist = np.min(dist_all, axis=-1)
+    dist_sorted = np.sort(dist)
+    unique_mask = np.concatenate(([True], np.diff(dist_sorted) > tol))
+    unique_dists = dist_sorted[unique_mask]
+    if nshells > len(unique_dists):
+        raise ValueError("nshells larger than available unique distance shells")
+    cutoff = unique_dists[nshells - 1]
+    return np.where(dist <= cutoff + tol)[0]
 
     
 def generate_kpoint_grid(nk1,nk2,nk3,sym_and_trev,IBZ=True,eps=1.0e-5):

--- a/yambopy/kpoints.py
+++ b/yambopy/kpoints.py
@@ -226,7 +226,7 @@ def regular_grid(nk1,nk2,nk3):
     return xkg.T # shape [nk,3]
 
 
-def find_kpatch(kpts, kcentre, lat_vecs, nshells=1, tol=1e-5, G_range=1):
+def find_kpatch(kpts, kcentre, lat_vecs, nshells=1, tol=1e-5, G_range=3):
     """
     Find k-points belonging to the first `nshells` neighbor shells
     around kcentre, including degeneracies and rigorous BZ mapping.
@@ -244,7 +244,7 @@ def find_kpatch(kpts, kcentre, lat_vecs, nshells=1, tol=1e-5, G_range=1):
     tol : float
         tolerance for degeneracy
     G_range : int
-        Range of surrounding reciprocal cells to check. G_range=1 checks 27 cells,
+        Range of surrounding reciprocal cells to check. G_range=2 checks 343 cells,
         which is sufficient when combined with initial rounding.
 
     Returns


### PR DESCRIPTION
- Fix inconsistent ordering of `exciton_energies` for finite `q` from `exc_ph_get_inputs`, which can occur when `k`-point and `q`-point orderings differ.
- Remove `bse_bands` to simplify and reduce required user input.
